### PR TITLE
compatibility with Weimer's and other scripting stuff

### DIFF
--- a/rpgsolaflirtpack/files/rpgsola.baf
+++ b/rpgsolaflirtpack/files/rpgsola.baf
@@ -1,4 +1,9 @@
 IF
+	InParty(Myself)
+	See(Player1)
+	!ActuallyInCombat()
+	!See([ENEMY])
+	!Range([NEUTRAL],10)
 	Global("RPGSolaFlirtsStart","GLOBAL",0)
 	GlobalGT("SolaTalk","GLOBAL",5)
 	GlobalLT("SolaTalk","GLOBAL",11)
@@ -8,6 +13,62 @@ THEN
 		RealSetGlobalTimer("RPGSolaFlirt","GLOBAL",300)
 END
 
+//outside town?
+IF
+	Global("RPGSolaFlirtSOA_Inside Town","GLOBAL",1)
+	!AreaCheck("AR0700")
+	!AreaCheck("AR0500")
+	!AreaCheck("AR0400")
+	!AreaCheck("AR0300")
+	!AreaCheck("AR0900")
+	!AreaCheck("AR1000")
+	!AreaCheck("AR0020")
+	!AreaCheck("AR1100")
+	!AreaCheck("AR2000")
+	!AreaCheck("AR1600")
+	!AreaCheck("AR5000")
+	!AreaCheck("AR5500")
+	InParty(Myself)
+	!StateCheck(Myself,CD_STATE_NOTVALID)
+	!StateCheck(Player1,CD_STATE_NOTVALID)
+	GlobalGT("SolaTalk","GLOBAL",5)
+	GlobalLT("SolaTalk","GLOBAL",11)
+	See(Player1)
+	CombatCounter(0)
+	!See([ENEMY])
+THEN
+	RESPONSE #100
+		SetGlobal("RPGSolaFlirtSOA_Inside Town","GLOBAL",0)
+END
+
+// Detect: inside a town?
+IF
+	Global("RPGSolaFlirtSOA_Inside Town","GLOBAL",0)
+	OR(12)
+		AreaCheck("AR0700")
+		AreaCheck("AR0500")
+		AreaCheck("AR0400")
+		AreaCheck("AR0300")
+		AreaCheck("AR0900")
+		AreaCheck("AR1000")
+		AreaCheck("AR0020")
+		AreaCheck("AR1100")
+		AreaCheck("AR2000")
+		AreaCheck("AR1600")
+		AreaCheck("AR5000")
+		AreaCheck("AR5500")
+	InParty(Myself)
+	!StateCheck(Myself,CD_STATE_NOTVALID)
+	!StateCheck(Player1,CD_STATE_NOTVALID)
+	GlobalGT("SolaTalk","GLOBAL",5)
+	GlobalLT("SolaTalk","GLOBAL",11)
+	See(Player1)
+	CombatCounter(0)
+	!See([ENEMY])
+THEN
+	RESPONSE #100
+		SetGlobal("RPGSolaFlirtSOA_Inside Town","GLOBAL",1)
+END
 
 /* ---------------------- *
  *  Fire SoA Sola Flirts  *
@@ -17,9 +78,11 @@ IF
 	Global("RPGDisableFlirts","GLOBAL",0)
 	Global("RPGSolaStartFlirtSOA","GLOBAL",0)
 	InParty(Myself)
-	!StateCheck(Player1,STATE_SLEEPING)
+	!StateCheck(Myself,CD_STATE_NOTVALID)
+	!StateCheck(Player1,CD_STATE_NOTVALID)
 	GlobalGT("SolaTalk","GLOBAL",5)
 	GlobalLT("SolaTalk","GLOBAL",11)
+	GlobalLT("Chapter","GLOBAL",%bg2_chapter_8%)
 	See(Player1)
 	CombatCounter(0)
 	!See([ENEMY])
@@ -49,6 +112,11 @@ THEN
 END
 
 IF
+	InParty(Myself)
+	See(Player1)
+	!ActuallyInCombat()
+	!See([ENEMY])
+	!Range([NEUTRAL],10)
 	RealGlobalTimerExpired("RPGSolaFlirt","GLOBAL")
 	Global("RPGSolaStartFlirtSOA","GLOBAL",1)
 THEN
@@ -59,6 +127,11 @@ THEN
 END
 
 IF
+	InParty(Myself)
+	See(Player1)
+	!ActuallyInCombat()
+	!See([ENEMY])
+	!Range([NEUTRAL],10)
 	RealGlobalTimerExpired("RPGSolaFlirt","GLOBAL")
 	!CombatCounter(0)
 THEN
@@ -71,6 +144,11 @@ END
  *  TOB  *
  * ----- */
 IF
+	InParty(Myself)
+	See(Player1)
+	!ActuallyInCombat()
+	!See([ENEMY])
+	!Range([NEUTRAL],10)
 	Global("RPGSolaFlirtsStartTOB","GLOBAL",0)
 	OR(2)
 		GlobalGT("Chapter","GLOBAL",%bg2_chapter_7%)
@@ -86,7 +164,8 @@ IF
 	Global("RPGSolaStartFlirtTOB","GLOBAL",0)
 	Global("RPGDisableFlirts","GLOBAL",0)
 	InParty(Myself)
-	!StateCheck(Player1,STATE_SLEEPING)
+	!StateCheck(Myself,CD_STATE_NOTVALID)
+	!StateCheck(Player1,CD_STATE_NOTVALID)
 	GlobalLT("SolaTalk","GLOBAL",16)
 	OR(2)
 		GlobalGT("Chapter","GLOBAL",%bg2_chapter_7%)
@@ -103,6 +182,11 @@ THEN
 END
 
 IF
+	InParty(Myself)
+	See(Player1)
+	!ActuallyInCombat()
+	!See([ENEMY])
+	!Range([NEUTRAL],10)
 	RealGlobalTimerExpired("RPGSolaFlirtTOB","GLOBAL")
 	Global("RPGSolaStartFlirtTOB","GLOBAL",1)
 THEN
@@ -111,6 +195,7 @@ THEN
 		RealSetGlobalTimer("RPGSolaFlirtTOB","GLOBAL",1500)
 END
 
+/*
 IF
 	RealGlobalTimerExpired("RPGSolaFlirtTOB","GLOBAL")
 	ActuallyInCombat()
@@ -119,6 +204,7 @@ THEN
 		SetGlobal("RPGSolaStartFlirtTOB","GLOBAL",0)
 		RealSetGlobalTimer("RPGSolaFlirtTOB","GLOBAL",100)
 END
+*/
 
 /* -------- *
  *  Nookie  *
@@ -128,7 +214,8 @@ IF
 	Global("RPGSolaNookie","GLOBAL",0)
 	Global("RPGSolaDisableFlirts","GLOBAL",0)
 	InParty(Myself)
-	!StateCheck(Player1,STATE_SLEEPING)
+	!StateCheck(Myself,CD_STATE_NOTVALID)
+	!StateCheck(Player1,CD_STATE_NOTVALID)
 	GlobalGT("SolaTalk","GLOBAL",15)
 	See(Player1)
 	!ActuallyInCombat()
@@ -142,6 +229,11 @@ THEN
 END
 
 IF
+	InParty(Myself)
+	See(Player1)
+	!ActuallyInCombat()
+	!See([ENEMY])
+	!Range([NEUTRAL],10)
 	RealGlobalTimerExpired("RPGSolaNookie","LOCALS")
 	Global("RPGSolaStartFlirtTOB","GLOBAL",1)
 THEN
@@ -151,6 +243,11 @@ THEN
 END
 
 IF
+	InParty(Myself)
+	See(Player1)
+	!ActuallyInCombat()
+	!See([ENEMY])
+	!Range([NEUTRAL],10)
 	RealGlobalTimerExpired("RPGSolaNookie","LOCALS")
 	ActuallyInCombat()
 THEN
@@ -167,7 +264,10 @@ IF
 	!Detect([EVILBUTBLUE])
 	!Detect([NEUTRAL])
 	InParty(Myself)
+	!StateCheck(Myself,CD_STATE_NOTVALID)
+	!StateCheck(Player1,CD_STATE_NOTVALID)
 	See(Player1)
+	!ActuallyInCombat()
 THEN
 	RESPONSE #100
 		SetGlobal("DeadlySpider","GLOBAL",1)

--- a/rpgsolaflirtpack/files/rpgsolaflirts.d
+++ b/rpgsolaflirtpack/files/rpgsolaflirts.d
@@ -4,10 +4,12 @@ APPEND SOLA
  *  Sola Initiated Flirts - For SoA  *
  * --------------------------------- */
 
-IF WEIGHT #-1 ~Global("RPGDisableFlirts","GLOBAL",0)
-Global("RPGSolaStartFlirtSOA","GLOBAL",1)
+IF WEIGHT #-1 ~Global("RPGSolaStartFlirtSOA","GLOBAL",1)
+/*
+Global("RPGDisableFlirts","GLOBAL",0)
 See(Player1)
-!StateCheck(Player1,STATE_SLEEPING)
+!StateCheck(Myself,CD_STATE_NOTVALID)
+!StateCheck(Player1,CD_STATE_NOTVALID)
 CombatCounter(0)
 GlobalGT("SolaTalk","GLOBAL",5)
 GlobalLT("SolaTalk","GLOBAL",11)
@@ -31,7 +33,8 @@ GlobalLT("Chapter","GLOBAL",%bg2_chapter_8%)
 !AreaCheck("AR2210")
 !AreaCheck("AR2400")
 !AreaCheck("AR2401")
-!AreaCheck("AR2402")~
+!AreaCheck("AR2402") */
+~
 THEN BEGIN solainitiatedflirts1
 SAY @0
 = @1
@@ -194,13 +197,15 @@ END
  *  Sola Initiated Flirts - For ToB  *
  * --------------------------------- */
 
-IF WEIGHT #-2 ~Global("RPGDisableFlirts","GLOBAL",0)
-Global("RPGSolaFlirtsStartTOB","GLOBAL",1)
+IF WEIGHT #-2 ~Global("RPGSolaFlirtsStartTOB","GLOBAL",1)
+/*
+Global("RPGDisableFlirts","GLOBAL",0)
 See(Player1)
 !StateCheck(Player1,STATE_SLEEPING)
 CombatCounter(0)
 GlobalGT("SolaTalk","GLOBAL",10)
-GlobalLT("SolaTalk","GLOBAL",16)~
+GlobalLT("SolaTalk","GLOBAL",16) */
+~
 THEN BEGIN solainitiatedflirts2
 SAY @201
 IF ~RandomNum(22,22)~ THEN DO ~IncrementGlobal("RPGSolaRandFlirt","LOCALS",1)~ GOTO solastretch1
@@ -450,10 +455,26 @@ GlobalLT("Chapter","GLOBAL",%bg2_chapter_8%)
 THEN BEGIN pcinitflirts1
 SAY @59
 = @60
-IF ~RandomNum(4,1)~ THEN REPLY @65 DO ~IncrementGlobal("RPGSolaFlirt","GLOBAL",1)~ GOTO squeeze1
-IF ~RandomNum(4,2)~ THEN REPLY @65 DO ~IncrementGlobal("RPGSolaFlirt","GLOBAL",1)~ GOTO squeeze3
-IF ~RandomNum(4,3)~ THEN REPLY @65 DO ~IncrementGlobal("RPGSolaFlirt","GLOBAL",1)~ GOTO squeeze3
-IF ~RandomNum(4,4)~ THEN REPLY @65 DO ~IncrementGlobal("RPGSolaFlirt","GLOBAL",1)~ GOTO squeeze1
+IF ~RandomNum(4,1)
+OR(2)
+Global("RPGSolaFlirtSOA_Inside Town","GLOBAL",0)
+Global("RPGSolaFlirtSOA_Inside Town","GLOBAL",2)~ THEN REPLY @65 DO ~IncrementGlobal("RPGSolaFlirt","GLOBAL",1)~ GOTO squeeze1
+IF ~RandomNum(4,2)
+OR(2)
+Global("RPGSolaFlirtSOA_Inside Town","GLOBAL",0)
+Global("RPGSolaFlirtSOA_Inside Town","GLOBAL",2)~ THEN REPLY @65 DO ~IncrementGlobal("RPGSolaFlirt","GLOBAL",1)~ GOTO squeeze3
+IF ~RandomNum(4,3)
+OR(2)
+Global("RPGSolaFlirtSOA_Inside Town","GLOBAL",0)
+Global("RPGSolaFlirtSOA_Inside Town","GLOBAL",2)~ THEN REPLY @65 DO ~IncrementGlobal("RPGSolaFlirt","GLOBAL",1)~ GOTO squeeze3
+IF ~RandomNum(4,4)
+OR(2)
+Global("RPGSolaFlirtSOA_Inside Town","GLOBAL",0)
+Global("RPGSolaFlirtSOA_Inside Town","GLOBAL",2)~ THEN REPLY @65 DO ~IncrementGlobal("RPGSolaFlirt","GLOBAL",1)~ GOTO squeeze1
+
+/* hug inside a town - plays once */
+
+IF ~Global("RPGSolaFlirtSOA_Inside Town","GLOBAL",1)~ THEN REPLY @65 DO ~SetGlobal("RPGSolaFlirtSOA_Inside Town","GLOBAL",2) IncrementGlobal("RPGSolaFlirt","GLOBAL",1)~ GOTO squeeze2
 
 IF ~RandomNum(4,1)~ THEN REPLY @66 DO ~IncrementGlobal("RPGSolaFlirt","GLOBAL",1)~ GOTO gladjoin1
 IF ~RandomNum(4,2)~ THEN REPLY @66 DO ~IncrementGlobal("RPGSolaFlirt","GLOBAL",1)~ GOTO gladjoin2
@@ -490,23 +511,7 @@ IF ~RandomNum(4,2)~ THEN REPLY @72 DO ~IncrementGlobal("RPGSolaFlirt","GLOBAL",1
 IF ~RandomNum(4,3)~ THEN REPLY @72 DO ~IncrementGlobal("RPGSolaFlirt","GLOBAL",1)~ GOTO smile3
 IF ~RandomNum(4,4)~ THEN REPLY @72 DO ~IncrementGlobal("RPGSolaFlirt","GLOBAL",1)~ GOTO smile4
 
-IF ~RandomNum(4,1)
-OR(12)
-AreaCheck("AR0700")
-AreaCheck("AR0500")
-AreaCheck("AR0400")
-AreaCheck("AR0300")
-AreaCheck("AR0900")
-AreaCheck("AR1000")
-AreaCheck("AR0020")
-AreaCheck("AR1100")
-AreaCheck("AR2000")
-AreaCheck("AR1600")
-AreaCheck("AR5000")
-AreaCheck("AR5500")~ THEN REPLY @65 DO ~IncrementGlobal("RPGSolaFlirt","GLOBAL",1)~ GOTO squeeze2
-
-IF ~RandomNum(4,1)
-OR(10)
+IF ~OR(10)
 AreaCheck("AR0704")
 AreaCheck("AR0709")
 AreaCheck("AR0406")
@@ -516,11 +521,13 @@ AreaCheck("AR0021")
 AreaCheck("AR0313")
 AreaCheck("AR1105")
 AreaCheck("AR2010")
-AreaCheck("AR1602")~ THEN REPLY @75 DO ~IncrementGlobal("RPGSolaFlirt","GLOBAL",1)~ GOTO drinkoffer
+AreaCheck("AR1602")
+Global("RPGSolaFlirt_75","LOCALS",0)~ THEN REPLY @75 DO ~IncrementGlobal("RPGSolaFlirt","GLOBAL",1) SetGlobal("RPGSolaFlirt_75","LOCALS",1)~ GOTO drinkoffer
 
-IF ~RandomNum(4,1)~ THEN REPLY @77 DO ~IncrementGlobal("RPGSolaFlirt","GLOBAL",1)~ GOTO friends
+IF ~~ THEN REPLY @77 DO ~IncrementGlobal("RPGSolaFlirt","GLOBAL",1)~ GOTO friends
 
 IF ~~ THEN REPLY @86 EXIT
+COPY_TRANS sola %SolaState130%
 END
 
 IF ~~ THEN BEGIN squeeze1
@@ -830,6 +837,7 @@ IF ~RandomNum(4,4)~ THEN REPLY @80 DO ~IncrementGlobal("RPGSolaFlirt","GLOBAL",1
 //IF ~RandomNum(4,1) AreaCheck("2401")~ THEN REPLY @74 DO ~IncrementGlobal("RPGSolaRandFlirt","LOCALS",1)~ GOTO sexed4a//
 
 IF ~~ THEN REPLY @86 EXIT
+COPY_TRANS sola %SolaState130%
 END
 
 IF ~~ THEN BEGIN squeeze2a
@@ -1204,6 +1212,7 @@ AreaCheck("AR2010")
 AreaCheck("AR1602")~ THEN REPLY @76 DO ~IncrementGlobal("RPGSolaFlirt","GLOBAL",1)~ GOTO bathe3
 
 IF ~~ THEN REPLY @86 EXIT
+COPY_TRANS sola %SolaState130%
 END
 
 IF ~~ THEN BEGIN squeeze2b

--- a/rpgsolaflirtpack/rpgsolaflirtpack.tp2
+++ b/rpgsolaflirtpack/rpgsolaflirtpack.tp2
@@ -70,6 +70,10 @@ END ELSE BEGIN
 	COPY_EXISTING ~sw1h01.itm~ ~override/rpgsolaflirtpack.rpgd~
 END
 
+/* STATE.IDS patching to ToB - thanks, Cam, if you read it */
+  /* adds custom IsValidForPartyDialogue state */
+  APPEND ~STATE.IDS~ ~0x80101FEF CD_STATE_NOTVALID~ UNLESS ~CD_STATE_NOTVALID~
+
 /*
 // Gwendolyne's Workaround to fix the no-initiating flirt options when clicking on Solaufein for the first time. Not tested in game.
 // Replaces the old code that was not patching anything:


### PR DESCRIPTION
changelog jastey:
-added InParty(Myself)
	See(Player1)
	!ActuallyInCombat()
	!See([ENEMY])
to all scriptblocks so they do not interrupt fighting orders.
-removed script block to reset timer while in combat. No scriptblocks should be executed during combat as they interrupt Solaufein's fighting.
-added
	!StateCheck(Myself,CD_STATE_NOTVALID)
	!StateCheck(Player1,CD_STATE_NOTVALID)
to all script blocks that trigger dialogues. (replaved the STATE_SLEEPING)
-removed wrong randomNum in PIDs
-"Hug Solaufein" in town will only play once. detection of town via script toggle varible "RPGSolaFlirtSOA_Inside Town"

-PID from original Solaufein mod will be added to Flirts-PIDs. This way, no possibilities to communivate with Solaufein (e.g. skip the hart fight) will be lost.
-removed unnecessary trigger variables from Solaufein initiated flirt dialogues (trigger dialogues by the trigger variable only).
-PID flirt "buy Solaufein a drink" inside tavern will only be available once.